### PR TITLE
feat: redirection from the experiment page if no extension is installed

### DIFF
--- a/src/routes/project-berlin-experiment/+page.js
+++ b/src/routes/project-berlin-experiment/+page.js
@@ -1,8 +1,18 @@
 export const ssr = false;
 import { PUBLIC_EXTENSION_ID } from '$env/static/public';
+import { goto } from '$app/navigation';
 
 /** @type {import('./$types').PageLoad} */
 export async function load() {
+	// This only works in Chrome
+	if (!window.chrome || !window.chrome.runtime) {
+		goto('../installation');
+	} else {
+		window.chrome.runtime.sendMessage(PUBLIC_EXTENSION_ID, {
+			type: 'is_installed'
+		});
+	}
+
 	let postsRequest = new Promise((resolve, reject) => {
 		chrome.runtime.sendMessage(PUBLIC_EXTENSION_ID, { type: 'get_posts' }, (data) => {
 			if (data) {


### PR DESCRIPTION
# (PB-72) Redirection from experiment page if no extension installed

## Related Ticket/PR
- [Jira ticket](https://whotargetsme.atlassian.net/browse/PB-72)

---

## Changes
This PR adds the check for extension in the Project Berlin Experiment page so that a user does not see an error message if they find themselves on the page, but don't have the extension installed
