### PR TITLE
Posthog identity error fixed when extension is not installed

### DIFF
--- a/src/routes/installation/+page.js
+++ b/src/routes/installation/+page.js
@@ -5,11 +5,14 @@ export function load() {
 
 	const { prolific_pid, study_id, session_id, form_id } = prolific_params;
 	const hasProlificParams = prolific_pid && study_id && session_id;
+	const hasExtension = window.chrome && window.chrome.runtime;
+	const landingPageUrl = `/landing?prolific_pid=${prolific_pid}&study_id=${study_id}&session_id=${session_id}&form_id=${form_id}`;
 
-	if (window.chrome && window.chrome.runtime && hasProlificParams) {
-		window.location.href = `/landing?prolific_pid=${prolific_pid}&study_id=${study_id}&session_id=${session_id}&form_id=${form_id}`;
+	if (hasExtension && hasProlificParams) {
+		window.location.href = landingPageUrl;
+	} else if (!hasExtension) {
+		return;
 	} else if (!hasProlificParams) {
 		goto('../landing');
 	}
-	return {};
 }


### PR DESCRIPTION
# (PB-84) Fixing posthog identity error when extension is not installed

## Related Ticket/PR
- [Jira ticket](https://whotargetsme.atlassian.net/jira/software/projects/PB/boards/5?selectedIssue=PB-84)

---

## Changes
This PR  handles errors that occur in the landing page when extension is not installed. Redirects participants to extension installation link.

---

## Concerns
None
---

## Requirements Before Merging
None
