### PR TITLE
refactor: unique names set for posthog events with wtm_ included

### DIFF
--- a/src/components/TrackedEvent.svelte
+++ b/src/components/TrackedEvent.svelte
@@ -21,7 +21,7 @@
 				element.nodeName.charAt(0) + element.nodeName.substring(1).toLowerCase() + ' clicked';
 		}
 
-		posthog.capture(eventName, {
+		posthog.capture(`wtm_${eventName}`, {
 			engagement: message,
 			'post-data': facebookNewsFeedInterceptedJSONExtractor(postMetaData)
 		});

--- a/src/routes/wtm-experiment/+page.svelte
+++ b/src/routes/wtm-experiment/+page.svelte
@@ -23,7 +23,7 @@
 		posts.map((post) => {
 			postMetaData.push(facebookNewsFeedInterceptedJSONExtractor(post));
 		});
-		posthog.capture('post-meta-data', postMetaData);
+		posthog.capture('wtm_all-post-meta-data', postMetaData);
 	}
 
 	let isStudyComplete: boolean;


### PR DESCRIPTION
# ((PB:102) Posthog event names should be unique

## Related Ticket/PR
- [Jira ticket](https://whotargetsme.atlassian.net/browse/PB-102)

---

## Changes
This PR changes the post-meta-data to wtm_all-post-meta-data and the tracked events to start with wtm_

---

## Concerns
none

---

## Requirements Before Merging
none